### PR TITLE
refactored component check

### DIFF
--- a/platform-team/index.ts
+++ b/platform-team/index.ts
@@ -1,11 +1,12 @@
 import { PolicyPack, validateResourceOfType } from "@pulumi/policy";
+import { log } from "@pulumi/pulumi";
 
 new PolicyPack("platform-team", {
     policies: [
         //// Component usage and allowed resource types check
         {
             name: "check-component-usage",
-            description: "COMPONENT USAGE CHECK:Verifies if certain resource types are created outside of a component.",
+            description: "COMPONENT USAGE CHECK:Verifies approved components are used.",
             enforcementLevel: "advisory",
             // Uses policy config. See README for links to docs.
             // See colocated `platform-team-policy.json` for the config file and note how the JSON object is keyed by the policy name. 
@@ -19,40 +20,64 @@ new PolicyPack("platform-team", {
                     }
                 }
             },
-            validateStack: (stack, reportViolation) => {
+            validateResource: (res, reportViolation) => {
+                // Ignore provider resources and the stack itself.
+                const ignoreTypeRegExp =  new RegExp("pulumi:providers|pulumi:pulumi:Stack")
+                if (ignoreTypeRegExp.test(res.type)) {
+                    log.debug(`Ignoring resource, ${res.name} since it is of type ${res.type}`);
+                    return;
+                }
+
                 // Get list of approved components from policy configuration.
                 // This is an array of objects where the key is the component type and the value is the version.
-                const approvedComponents = stack.getConfig<{approvedComponentTypes: string[]}>().approvedComponentTypes;
+                const approvedComponents = res.getConfig<{approvedComponentTypes: string[]}>().approvedComponentTypes;
+                if (!approvedComponents) {
+                    log.error("No approved components found in policy configuration.");
+                    return;
+                }
 
                 // Get list of allowed types
                 // This is an array of resource types that are allowed to be used outside of a component.
-                const allowedTypes = stack.getConfig<{allowedResourceTypes: string[]}>().allowedResourceTypes;
-
-                // Get resources in the stack that are not "standard" Pulumi types
-                const ignoreTypeRegExp =  new RegExp("pulumi:providers|pulumi:pulumi:Stack")
-                let resourcesToCheck = stack.resources.filter(resource => !ignoreTypeRegExp.test(resource.type))
-
-                // Whittle down the list of resources by removing any that ARE approved component type
-                resourcesToCheck = resourcesToCheck.filter(resource => !approvedComponents.includes(resource.type))
-                // And remove those resources that are in the allowed types list
-                resourcesToCheck = resourcesToCheck.filter(resource => !allowedTypes.includes(resource.type))
-
-                // Now find any resources left that are not parented to an approved component. 
-                const unapprovedResources = resourcesToCheck.filter((resource) => !approvedComponents.includes(resource?.parent?.type || ""))
-
-                // And build a list of unique types across that set of resources to report to the user.
-                const unapprovedResourceTypes = unapprovedResources.map((resource) => ` ${resource.type}`).filter((value, index, array) => array.indexOf(value) === index)
-
-                // Throw an error if there are resources created outside of approved components.
-                if (unapprovedResourceTypes.length > 0) {
-                    reportViolation(
-                        `The following resource types should not be created outside of a platform-team provided component:\n${unapprovedResourceTypes}`
-                    );
+                const allowedTypes = res.getConfig<{allowedResourceTypes: string[]}>().allowedResourceTypes;
+                if (!allowedTypes) {
+                    log.error("No allowed types found in policy configuration.");
+                    return;
                 }
-            },
+
+                // Now check if the resource is parented to the stack since these are the resources declared directly in the program.
+                // If so, by definition these are the resources we care about.
+                // We can ignore any resources that are not direct children of the stack since the assumption is that if 
+                // a resource is declared in the program that uses an approved component, it doesn't matter what that component's
+                // children resources are since it's an approved component.
+                // And similarly, if the resource is an approved type, that's acceptable.
+                
+                // Check if the resource has a parent defined. 
+                // It should since the provider/stack filter above should have removed any resources that do not have a parent defined.
+                if (res.opts?.parent) {
+                    // Check if the resource is parented to the stack.
+                    const stackRegExp = new RegExp("pulumi:pulumi:Stack");
+                    if (stackRegExp.test(res.opts.parent)) {
+                        // Check if the resource is not an approved component type nor an approved resource type.
+                        // If not then report a violation.
+                        if ((!approvedComponents.includes(res.type)) && (!allowedTypes.includes(res.type))) {
+                            reportViolation(
+                                `The following resource is not an approved component or resource type:\nResource name: ${res.name}\nResource type: ${res.type}\nContact the platform team to get this resource type approved or check the approved components list.`
+                            );
+                        };
+                    } 
+                } else {
+                    log.info(`Resource, ${res.name}, of type ${res.type} is not parented to the stack.\nThis is unexpected and should be reported to the platform team.`);
+                }
+            }
         },
 
         // Component version check.
+        // This policy checks that if a component is used, it is the correct version.
+        // It uses "validateStack" instead of "validateResource" only to show it's use.
+        // Because "validateStack" is called after all resources have been validated, it introduces a loop-hole in that if one uses
+        // `pulumi up --skip-preview` this policy will not stop the udpate even if the policy is set to mandatory.
+        // But an assumption is that using an old version would likely not be a mandatory policy and thus shouldn't halt the update.
+        // Plus uing "validateStack" allows for a nice summary of all the resources that are out of date. 
         {
             name: "check-component-versions",
             description: "COMPONENT VERSION CHECK: Verifies that if a component is used, it is the correct version.",
@@ -94,8 +119,9 @@ new PolicyPack("platform-team", {
                 })
                 // Throw an error if there are resources created outside of approved components.
                 if (outofdateComponents.length > 0) {
+                    const outofdateComponentsString = outofdateComponents.join(", ");
                     reportViolation(
-                        `This stack is using out of date versions of the following components:\n${outofdateComponents}`
+                        `This stack is using out of date versions of the following components:\n${outofdateComponentsString}`
                     );
                 }
             },

--- a/platform-team/package-lock.json
+++ b/platform-team/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "platform-team",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "platform-team",
-            "version": "1.3.0",
+            "version": "1.4.0",
             "dependencies": {
                 "@pulumi/policy": "^1.3.0",
                 "@pulumi/pulumi": "^3.0.0"
@@ -570,9 +570,9 @@
             }
         },
         "node_modules/@pulumi/pulumi": {
-            "version": "3.163.0",
-            "resolved": "https://registry.npmjs.org/@pulumi/pulumi/-/pulumi-3.163.0.tgz",
-            "integrity": "sha512-GWiF52tzNKWxL1MyulRxfXbD+OaFs9Wmt2yATxCxz5JhJTW1JKQIAfi6sj0Hax0jSBM794T9FdAresb/myFFHA==",
+            "version": "3.169.0",
+            "resolved": "https://registry.npmjs.org/@pulumi/pulumi/-/pulumi-3.169.0.tgz",
+            "integrity": "sha512-l8x+gTySKWG2dRGvlScfl9EJaYgymkcUFaNAaz7lONYcvqllXXVw/mhbnsleNhC02gDiuP0p/9CfctHLqf75+Q==",
             "dependencies": {
                 "@grpc/grpc-js": "^1.10.1",
                 "@logdna/tail-file": "^2.0.6",
@@ -1929,9 +1929,9 @@
             }
         },
         "node_modules/module-details-from-path": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.3.tgz",
-            "integrity": "sha512-ySViT69/76t8VhE1xXHK6Ch4NcDd26gx0MzKXLO+F7NOtnqH68d9zF94nT8ZWSxXh8ELOERsnJO/sWt1xZYw5A=="
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+            "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w=="
         },
         "node_modules/ms": {
             "version": "2.1.3",
@@ -2348,9 +2348,9 @@
             }
         },
         "node_modules/protobufjs": {
-            "version": "7.5.0",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.0.tgz",
-            "integrity": "sha512-Z2E/kOY1QjoMlCytmexzYfDm/w5fKAiRwpSzGtdnXW1zC88Z2yXazHHrOtwCzn+7wSxyE8PYM4rvVcMphF9sOA==",
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
+            "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
             "hasInstallScript": true,
             "dependencies": {
                 "@protobufjs/aspromise": "^1.1.2",
@@ -2371,9 +2371,9 @@
             }
         },
         "node_modules/protobufjs/node_modules/@types/node": {
-            "version": "22.14.1",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.1.tgz",
-            "integrity": "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==",
+            "version": "22.15.17",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.17.tgz",
+            "integrity": "sha512-wIX2aSZL5FE+MR0JlvF87BNVrtFWf6AE6rxSE9X7OwnVvoyCQjpzSRJ+M87se/4QCkCiebQAqrJ0y6fwIyi7nw==",
             "dependencies": {
                 "undici-types": "~6.21.0"
             }

--- a/platform-team/package.json
+++ b/platform-team/package.json
@@ -1,6 +1,6 @@
 {
     "name": "platform-team",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "dependencies": {
         "@pulumi/pulumi": "^3.0.0",
         "@pulumi/policy": "^1.3.0"


### PR DESCRIPTION
The component usage check policy used stack validation instead of resource validation.
Because stack validation doesn't run until the end of the update, this meant that updates that skipped previews would not stop the update if the policy was set to mandatory.

So this refactor was to change to using resource validation.